### PR TITLE
Remove unused dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 946a5a1173be607c7c5c593358a0fb0c0d6af4400c978929ecdb19c3a37b53a8
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<35]
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -24,16 +24,13 @@ requirements:
     - python
     - cachecontrol >=0.12.4,<0.13.0
     # cachecontrol:filecache
-    - lockfile >=0.9
     - cachy >=0.3.0,<0.4.0
     - cleo >=0.8.1,<0.9.0
     - clikit >=0.6.2,<0.7.0
-    - html5lib >=1.0,<2.0
     - jsonschema >=3.1,<4.0
+    - html5lib >=1.0,<2.0
     - pexpect >=4.7.0,<5.0.0
     - pkginfo >=1.4,<2.0
-    - pyparsing >=2.2,<3.0
-    - pyrsistent >=0.14.2,<0.15.0
     - requests-toolbelt >=0.9.1,<0.10.0
     - requests >=2.18,<3.0
     - shellingham >=1.1,<2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - packaging >=20.4,<21.0
     - poetry-core >=1.0.0,<2.0.0
     - virtualenv >=20.0.26,<21.0.0
-    - keyring >=21.2.0,<21.3.0  # [py>=36]
+    - keyring >=21.2.0,<22.0.0  # [py>=36]
     # legacy python
     - importlib-metadata >=1.6.0,<2.0.0  # [py<38]
 


### PR DESCRIPTION
Compared against the [poetry `pyproject.toml`](https://github.com/python-poetry/poetry/blob/master/pyproject.toml) and sdist `setup.py`. I left `jsonschema` in because of python-poetry/poetry#3319 which I reported upstream.

At least the `pyrsistent` and `keyring` dependencies are holding back the Python 3.9 migration.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
